### PR TITLE
Cleanup

### DIFF
--- a/Mudz.Cli/Domain/GameEngine/Render.cs
+++ b/Mudz.Cli/Domain/GameEngine/Render.cs
@@ -157,7 +157,7 @@ namespace Mudz.Cli.Domain.GameEngine
         private static void ReplaceLine(string str)
         {
                 Console.SetCursorPosition(0, Console.CursorTop); // Move to the start of the line.
-                Console.Write(new String(' ', Console.BufferWidth - 1)); // Replace with nothing.
+                Console.Write(new string(' ', Console.BufferWidth - 1)); // Replace with nothing.
                 Console.SetCursorPosition(0, Console.CursorTop); // Move to the start of the line.
                 Console.WriteLine(str); // Replace line
         }
@@ -165,7 +165,7 @@ namespace Mudz.Cli.Domain.GameEngine
         public static void ClearPreviousLine()
         {
             Console.SetCursorPosition(0, Console.CursorTop - 1);
-            Console.Write(new String(' ', Console.BufferWidth - 1)); // Replace with nothing.
+            Console.Write(new string(' ', Console.BufferWidth - 1)); // Replace with nothing.
             Console.SetCursorPosition(0, Console.CursorTop); // Move to the start of the line.
         }
         #endregion

--- a/Mudz.Cli/Domain/Player/PlayerOne.cs
+++ b/Mudz.Cli/Domain/Player/PlayerOne.cs
@@ -1,15 +1,14 @@
-﻿
-using Mudz.Common.Domain.Environment.Map.Room;
+﻿using Mudz.Common.Domain.Environment.Map.Room;
 using Mudz.Common.Domain.Player;
 
 namespace Mudz.Cli.Domain.Player
 {
-    public static class PlayerOne
+	public static class PlayerOne
     {
         private static IPlayer _instance = null;
         private static RoomKey _roomKey = null;
 
-        public static RoomKey CurrenLocation
+        public static RoomKey CurrentLocation
         {
             get{return _roomKey;}
             set { _roomKey = value; }

--- a/Mudz.Cli/Domain/easytcp/RenderStrategy.cs
+++ b/Mudz.Cli/Domain/easytcp/RenderStrategy.cs
@@ -63,7 +63,7 @@ namespace Mudz.Cli.Domain.EasyTcp
 
         private string DecideMessage(GameResponse gameResponse, ActionResult actionResult)
         {
-            if (PlayerOne.Instance == null) return String.Empty; // Likely a login screen that's getting the message but can ignore it.
+            if (PlayerOne.Instance == null) return string.Empty; // Likely a login screen that's getting the message but can ignore it.
 
             var roomEq = new RoomKeyEqualityComparer();
 
@@ -77,7 +77,7 @@ namespace Mudz.Cli.Domain.EasyTcp
                 return actionResult.RoomMessage;
             }
 
-            if (!String.IsNullOrEmpty(gameResponse.TargetName) &&
+            if (!string.IsNullOrEmpty(gameResponse.TargetName) &&
                 PlayerOne.Instance.Name.Equals(gameResponse.TargetName, StringComparison.InvariantCultureIgnoreCase))
             {
                 return actionResult.TargetMessage;

--- a/Mudz.Cli/Domain/easytcp/RenderStrategy.cs
+++ b/Mudz.Cli/Domain/easytcp/RenderStrategy.cs
@@ -49,7 +49,7 @@ namespace Mudz.Cli.Domain.EasyTcp
         {
             PlayerOne.Instance = gameResponse.RoomContent.GameObjects.Where(x => x.GameObjectType == GameObjectTypes.Player && x.GameObjectState.ToString() == GameObjectStates.InPlay.ToString())
         .Select(x => (IPlayer)x).FirstOrDefault(x => x.Name.Equals(PlayerOne.Instance.Name, StringComparison.InvariantCultureIgnoreCase));
-            PlayerOne.CurrenLocation = gameResponse.RoomContent.RoomKey;
+            PlayerOne.CurrentLocation = gameResponse.RoomContent.RoomKey;
         }
 
         private void DisplayActionItems(GameResponse gameResponse, List<ActionResult> actionItems)
@@ -67,12 +67,12 @@ namespace Mudz.Cli.Domain.EasyTcp
 
             var roomEq = new RoomKeyEqualityComparer();
 
-            if (IsRequestor(gameResponse) && roomEq.Equals(gameResponse.RoomContent.RoomKey, PlayerOne.CurrenLocation))
+            if (IsRequestor(gameResponse) && roomEq.Equals(gameResponse.RoomContent.RoomKey, PlayerOne.CurrentLocation))
             {
                 return actionResult.PlayerMessage;
             }
 
-            if (!IsRequestor(gameResponse) && roomEq.Equals(gameResponse.RoomContent.RoomKey, PlayerOne.CurrenLocation))
+            if (!IsRequestor(gameResponse) && roomEq.Equals(gameResponse.RoomContent.RoomKey, PlayerOne.CurrentLocation))
             {
                 return actionResult.RoomMessage;
             }

--- a/Mudz.Common/Domain/Environment/Map/Room/RoomKeyEqualityComparer.cs
+++ b/Mudz.Common/Domain/Environment/Map/Room/RoomKeyEqualityComparer.cs
@@ -11,7 +11,13 @@ namespace Mudz.Common.Domain.Environment.Map.Room
 
         public int GetHashCode(RoomKey obj)
         {
-            return obj.X.GetHashCode()*obj.Y;
+			unchecked
+			{
+				int hash = 17;
+				hash = hash * 23 + obj.X.GetHashCode();
+				hash = hash * 23 + obj.Y.GetHashCode();
+				return hash;
+			}
         }
     }
 }

--- a/Mudz.Core/Domain/BaseActor.cs
+++ b/Mudz.Core/Domain/BaseActor.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using Mudz.Common.Domain;
 using Mudz.Common.Domain.GameEngine;
 using Mudz.Common.Domain.Inventory;
@@ -8,7 +7,7 @@ using Mudz.Data.Domain.Localization;
 
 namespace Mudz.Core.Domain
 {
-    [Serializable]
+	[Serializable]
     public abstract class BaseActor : BaseGameObject, IActor
     {
         #region Game Engine

--- a/Mudz.Core/Domain/BaseActor.cs
+++ b/Mudz.Core/Domain/BaseActor.cs
@@ -80,7 +80,7 @@ namespace Mudz.Core.Domain
             return new ActionResult()
             {
                 WasSuccessful = false,
-                RoomMessage = String.Format(TextResourceRepository.TextResourceLookUpByCulture("en-us")[TextResourceNames.CannotRespondRoomMessage], this.Name),
+                RoomMessage = string.Format(TextResourceRepository.TextResourceLookUpByCulture("en-us")[TextResourceNames.CannotRespondRoomMessage], this.Name),
                 PlayerMessage = TextResourceRepository.TextResourceLookUpByCulture("en-us")[TextResourceNames.CannotRespondPlayerMessage]
             };
         }
@@ -90,7 +90,7 @@ namespace Mudz.Core.Domain
             return new ActionResult()
             {
                 WasSuccessful = false,
-                RoomMessage = String.Format("{0} does not have enough stamina (turns) to complete this action!", this.Name),
+                RoomMessage = string.Format("{0} does not have enough stamina (turns) to complete this action!", this.Name),
                 PlayerMessage = "You do not have enough stamia (turns) to complete this action!"
             };
 
@@ -111,26 +111,26 @@ namespace Mudz.Core.Domain
                 case GameActions.Fight:
                     amount = this.CalculateGameAction(actionContext.GameRequest.GameAction);
                     actionResult.WasSuccessful = true;
-                    actionResult.RoomMessage = String.Format("{0} attacks {1} for {2} damage!", this.Name, actionContext.Target.Name, amount);
-                    actionResult.PlayerMessage = String.Format("You attack {0} for {1} damage!", actionContext.Target.Name, amount);
+                    actionResult.RoomMessage = string.Format("{0} attacks {1} for {2} damage!", this.Name, actionContext.Target.Name, amount);
+                    actionResult.PlayerMessage = string.Format("You attack {0} for {1} damage!", actionContext.Target.Name, amount);
                     actionResult.Amount = amount;
                     return actionResult;
                 case GameActions.Repair:
                     amount = this.CalculateGameAction(actionContext.GameRequest.GameAction);
-                    actionResult.RoomMessage = String.Format("{0} repairs {1} for {2} hit points!", this.Name, actionContext.Target.Name, amount);
-                    actionResult.PlayerMessage = String.Format("You repair {0} for {1} hit points!", actionContext.Target.Name, amount);
+                    actionResult.RoomMessage = string.Format("{0} repairs {1} for {2} hit points!", this.Name, actionContext.Target.Name, amount);
+                    actionResult.PlayerMessage = string.Format("You repair {0} for {1} hit points!", actionContext.Target.Name, amount);
                     actionResult.Amount = amount;
                     return actionResult;
                 case GameActions.Negotiate:
                     amount = this.CalculateGameAction(actionContext.GameRequest.GameAction);
-                    actionResult.RoomMessage = String.Format("{0} negotiates with {1} for {2} points!", this.Name, actionContext.Target.Name, amount);
-                    actionResult.PlayerMessage = String.Format("You negotiate with {0} for {1} points!", actionContext.Target.Name, amount);
+                    actionResult.RoomMessage = string.Format("{0} negotiates with {1} for {2} points!", this.Name, actionContext.Target.Name, amount);
+                    actionResult.PlayerMessage = string.Format("You negotiate with {0} for {1} points!", actionContext.Target.Name, amount);
                     actionResult.Amount = amount;
                     return actionResult;
                 case GameActions.Heal:
                     amount = this.CalculateGameAction(actionContext.GameRequest.GameAction);
-                    actionResult.RoomMessage = String.Format("{0} heals {1} for {2} damage!", actionContext.Player.Name, actionContext.Target.Name, amount);
-                    actionResult.PlayerMessage = String.Format("You heal {0} for {1} damage!", actionContext.Target.Name, amount);
+                    actionResult.RoomMessage = string.Format("{0} heals {1} for {2} damage!", actionContext.Player.Name, actionContext.Target.Name, amount);
+                    actionResult.PlayerMessage = string.Format("You heal {0} for {1} damage!", actionContext.Target.Name, amount);
                     actionResult.Amount = amount;
                     return actionResult;
                 default:
@@ -145,22 +145,22 @@ namespace Mudz.Core.Domain
                 case GameActions.Fight:
                     TakeDamage(actionResult.Amount);
                     actionResult.WasSuccessful = true;
-                    actionResult.TargetMessage = String.Format("{0} attacks you for {1} damage!", playerName, actionResult.Amount);
+                    actionResult.TargetMessage = string.Format("{0} attacks you for {1} damage!", playerName, actionResult.Amount);
                     actionResult.Amount = actionResult.Amount;
                     return actionResult;
                 case GameActions.Repair:
                     actionResult.WasSuccessful = false;
-                    actionResult.TargetMessage = String.Format("{0} tries to wrap you in duct tape but you wiggle free!", playerName);
+                    actionResult.TargetMessage = string.Format("{0} tries to wrap you in duct tape but you wiggle free!", playerName);
                     return actionResult;
                 case GameActions.Negotiate:
                     actionResult.WasSuccessful = true;
-                    actionResult.TargetMessage = String.Format("{0} negotiates with you for {1} points!", playerName, actionResult.Amount);
+                    actionResult.TargetMessage = string.Format("{0} negotiates with you for {1} points!", playerName, actionResult.Amount);
                     actionResult.Amount = actionResult.Amount;
                     return actionResult;
                 case GameActions.Heal:
                     RestoreHealth(actionResult.Amount);
                     actionResult.WasSuccessful = true;
-                    actionResult.TargetMessage = String.Format("{0} heals you for {1} damage!", playerName, actionResult.Amount);
+                    actionResult.TargetMessage = string.Format("{0} heals you for {1} damage!", playerName, actionResult.Amount);
                     actionResult.Amount = actionResult.Amount;
                     return actionResult;
                 default:
@@ -179,8 +179,8 @@ namespace Mudz.Core.Domain
             return new ActionResult()
             {
                 WasSuccessful = true,
-                RoomMessage = String.Format("{0} takes {1} and quickly hides it away.", this.Name, item.Name),
-                PlayerMessage = String.Format("You take {0} and quickly hides it away.", item.Name)
+                RoomMessage = string.Format("{0} takes {1} and quickly hides it away.", this.Name, item.Name),
+                PlayerMessage = string.Format("You take {0} and quickly hides it away.", item.Name)
             };
         }
 

--- a/Mudz.Core/Domain/BaseGameObject.cs
+++ b/Mudz.Core/Domain/BaseGameObject.cs
@@ -16,7 +16,7 @@ namespace Mudz.Core.Domain
         {
             get
             {
-                return String.Format("You are looking at {0}. {1}. Health: {2}.", Name, GetDescription(), HitPoints);
+                return string.Format("You are looking at {0}. {1}. Health: {2}.", Name, GetDescription(), HitPoints);
             }
         }
 

--- a/Mudz.Core/Domain/GameEngine/Handler/BaseHandler.cs
+++ b/Mudz.Core/Domain/GameEngine/Handler/BaseHandler.cs
@@ -73,7 +73,7 @@ namespace Mudz.Core.Domain.GameEngine.Handler
             return new ActionResult()
             {
                 WasSuccessful = false,
-                PlayerMessage = String.Format("Sorry, {0} is out of play!", gameObject.Name)
+                PlayerMessage = string.Format("Sorry, {0} is out of play!", gameObject.Name)
             };
         }
 
@@ -82,7 +82,7 @@ namespace Mudz.Core.Domain.GameEngine.Handler
             return new ActionResult()
             {
                 WasSuccessful = false,
-                PlayerMessage = String.Format("Sorry, there doesn't seem to be '{0}' here.", gameObject.Name)
+                PlayerMessage = string.Format("Sorry, there doesn't seem to be '{0}' here.", gameObject.Name)
             };
         }
 
@@ -91,7 +91,7 @@ namespace Mudz.Core.Domain.GameEngine.Handler
             return new ActionResult()
             {
                 WasSuccessful = false,
-                PlayerMessage = String.Format("That doesn't make any sense. '{0}' is not a valid target for this command.", gameObject.Name)
+                PlayerMessage = string.Format("That doesn't make any sense. '{0}' is not a valid target for this command.", gameObject.Name)
             };
         }
 

--- a/Mudz.Core/Domain/GameEngine/Handler/CommandHandler.cs
+++ b/Mudz.Core/Domain/GameEngine/Handler/CommandHandler.cs
@@ -84,7 +84,7 @@ namespace Mudz.Core.Domain.GameEngine.Handler
                     actionContext.ActionItems.Add(actionResult);
                     break;
                 case GameActions.LookAround:
-                    actionResult.RoomMessage = String.Format("{0} looks around.", actionContext.Player.Name);
+                    actionResult.RoomMessage = string.Format("{0} looks around.", actionContext.Player.Name);
                     actionResult.WasSuccessful = true;
                     actionContext.ActionItems.Add(actionResult);
                     break;

--- a/Mudz.Core/Domain/Monster/BaseMonster.cs
+++ b/Mudz.Core/Domain/Monster/BaseMonster.cs
@@ -4,11 +4,10 @@ using Mudz.Common.Domain;
 using Mudz.Common.Domain.GameEngine;
 using Mudz.Common.Domain.Inventory;
 using Mudz.Common.Domain.Monster;
-using Mudz.Core.Model.Domain;
 
 namespace Mudz.Core.Domain.Monster
 {
-    [Serializable]
+	[Serializable]
     public abstract class BaseMonster : BaseActor, IMonster
     {
         protected BaseMonster()

--- a/Mudz.Core/Domain/Npc/Npc.cs
+++ b/Mudz.Core/Domain/Npc/Npc.cs
@@ -2,11 +2,10 @@
 using Mudz.Common.Domain;
 using Mudz.Common.Domain.GameEngine;
 using Mudz.Common.Domain.Npc;
-using Mudz.Core.Model.Domain;
 
 namespace Mudz.Core.Domain.Npc
 {
-    [Serializable]
+	[Serializable]
     public abstract class Npc : BaseGameObject, INpc
     {
         protected Npc(string name)

--- a/Mudz.Core/Domain/Player/Player.cs
+++ b/Mudz.Core/Domain/Player/Player.cs
@@ -92,7 +92,7 @@ namespace Mudz.Core.Domain.Player
         public override string GetDescription()
         {
             var physique = (this.Strength > 100) ? "Appears strongly built." : "Has a normal build";
-            var desc = String.Format("{0}. {1}.", physique, _actionStrategy.GetClassDescription());
+            var desc = string.Format("{0}. {1}.", physique, _actionStrategy.GetClassDescription());
             return desc;
         }
 

--- a/Mudz.Core/Domain/Player/Player.cs
+++ b/Mudz.Core/Domain/Player/Player.cs
@@ -7,12 +7,11 @@ using Mudz.Common.Domain.Inventory;
 using Mudz.Common.Domain.Player;
 using Mudz.Common.Domain.Player.Inventory;
 using Mudz.Core.Domain.Player.Inventory.Item.Weapon;
-using Mudz.Core.Model.Domain;
 using Mudz.Core.Model.Domain.Player.Class;
 
 namespace Mudz.Core.Domain.Player
 {
-    [Serializable]
+	[Serializable]
     public sealed class Player : BaseActor, IPlayer
     {
         public Player(string name, ActorGenderTypes gender, PlayerTypes playerType, IPlayerActionStrategy actionStrategy)

--- a/Mudz.Data/Domain/Localization/TextResourceRepository.cs
+++ b/Mudz.Data/Domain/Localization/TextResourceRepository.cs
@@ -9,29 +9,26 @@ namespace Mudz.Data.Domain.Localization
     {
         public static IEnumerable<TextResource> GetResources()
         {
-            var resources = new List<TextResource>();
 
             //* CannotRespondRoom
-            resources.Add(new TextResource() { TextResourceName = TextResourceNames.CannotRespondRoomMessage, Culture = "en-us", Content = "{0} begins to move and then collapses!" });
-            resources.Add(new TextResource() { TextResourceName = TextResourceNames.CannotRespondPlayerMessage, Culture = "en-us", Content = "You try to move and collapse. Perhaps you need rest?" });
-            resources.Add(new TextResource() { TextResourceName = TextResourceNames.CannotRespondTargetMessage, Culture = "en-us", Content = "" });
+            yield return new TextResource() { TextResourceName = TextResourceNames.CannotRespondRoomMessage, Culture = "en-us", Content = "{0} begins to move and then collapses!" };
+            yield return new TextResource() { TextResourceName = TextResourceNames.CannotRespondPlayerMessage, Culture = "en-us", Content = "You try to move and collapse. Perhaps you need rest?" };
+            yield return new TextResource() { TextResourceName = TextResourceNames.CannotRespondTargetMessage, Culture = "en-us", Content = "" };
 
             //* NotEnoughStamina
-            resources.Add(new TextResource() { TextResourceName = TextResourceNames.NotEnoughStaminaRoomMessage, Culture = "en-us", Content = "{0} does not have enough stamina (turns) to complete this action!" });
-            resources.Add(new TextResource() { TextResourceName = TextResourceNames.NotEnoughStaminaPlayerMessage, Culture = "en-us", Content = "You do not have enough stamia (turns) to complete this action!" });
-            resources.Add(new TextResource() { TextResourceName = TextResourceNames.NotEnoughStaminaTargetMessage, Culture = "en-us", Content = "" });
+            yield return new TextResource() { TextResourceName = TextResourceNames.NotEnoughStaminaRoomMessage, Culture = "en-us", Content = "{0} does not have enough stamina (turns) to complete this action!" };
+            yield return new TextResource() { TextResourceName = TextResourceNames.NotEnoughStaminaPlayerMessage, Culture = "en-us", Content = "You do not have enough stamia (turns) to complete this action!" };
+            yield return new TextResource() { TextResourceName = TextResourceNames.NotEnoughStaminaTargetMessage, Culture = "en-us", Content = "" };
 
             //* Fight
-            resources.Add(new TextResource() { TextResourceName = TextResourceNames.FightRoomMessage, Culture = "en-us", Content = "" });
-            resources.Add(new TextResource() { TextResourceName = TextResourceNames.FightPlayerMessage, Culture = "en-us", Content = "" });
-            resources.Add(new TextResource() { TextResourceName = TextResourceNames.FightTargetMessage, Culture = "en-us", Content = "" });
+            yield return new TextResource() { TextResourceName = TextResourceNames.FightRoomMessage, Culture = "en-us", Content = "" };
+            yield return new TextResource() { TextResourceName = TextResourceNames.FightPlayerMessage, Culture = "en-us", Content = "" };
+            yield return new TextResource() { TextResourceName = TextResourceNames.FightTargetMessage, Culture = "en-us", Content = "" };
 
             ////* 
-            //resources.Add(new TextResource() { TextResourceName = TextResourceNames., Culture = "en-us", Content = "" });
-            //resources.Add(new TextResource() { TextResourceName = TextResourceNames., Culture = "en-us", Content = "" });
-            //resources.Add(new TextResource() { TextResourceName = TextResourceNames., Culture = "en-us", Content = "" });
-
-            return resources;
+            //yield return new TextResource() { TextResourceName = TextResourceNames., Culture = "en-us", Content = "" };
+            //yield return new TextResource() { TextResourceName = TextResourceNames., Culture = "en-us", Content = "" };
+            //yield return new TextResource() { TextResourceName = TextResourceNames., Culture = "en-us", Content = "" };
         }
 
         public static Dictionary<TextResourceNames, string> TextResourceLookUpByCulture(string culture)


### PR DESCRIPTION
Just some more cleanup tasks.

I've refrained from doing anything serious with the new Text Resources, but they hella mess right now. Every resource lookup causes a fresh seed (`GetResources`), which is then culture filtered (`GetResourcesByCulture`), then finally converted into a List, then a Dictionary (you didn't commit the last minute removal of `ToList` yet), which is finally hash compared for the correct resource. I'm all for avoiding pre-optimisation, but wow! :D :P

I'll see about adding issues for patterns/ideas/etc.
